### PR TITLE
Unpin PyNWB and HDMF versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - 3.6
+  - 3.7
+  - 3.8
 install:
 - sudo apt-get update
 - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ python:
   - 3.8
 install:
 - sudo apt-get update
-- if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh
-  -O miniconda.sh; else wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-  -O miniconda.sh; fi
+- wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 - bash miniconda.sh -b -p $HOME/miniconda
 - source "$HOME/miniconda/etc/profile.d/conda.sh"
 - hash -r

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - pip
-  - python=3.6
+  - python>=3.6
   - python-dateutil
   - setuptools
   - hdmf

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,6 @@ dependencies:
   - python=3.6
   - python-dateutil
   - setuptools
-  - hdmf==1.6.4
-  - pynwb==1.3.3
+  - hdmf
+  - pynwb
   - pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 hdmf_docutils
-hdmf==1.6.4
+hdmf
 pynwb

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,7 @@ setup_args = {
     'url': '',
     'license': 'BSD 3-Clause',
     'install_requires': [
-        'hdmf==1.6.4',
-        'pynwb==1.3.3'
+        'pynwb'
     ],
     'packages': find_packages('src/pynwb'),
     'package_dir': {'': 'src/pynwb'},


### PR DESCRIPTION
PyNWB and HDMF have received many updates since version 1.6.4. Some of these changes are needed by Frank Lab code that uses ndx-franklab-novela. PyNWB>=1.3.3 and HDMF>=1.6.4,<=2.3.0 work with the master branch of ndx-franklab-novela. So to avoid creating restraints on upstream packages, I recommend unpinning the PyNWB and HDMF version dependencies in `setup.py`.